### PR TITLE
Update sslThreadSlots.psc

### DIFF
--- a/scripts/Source/sslThreadSlots.psc
+++ b/scripts/Source/sslThreadSlots.psc
@@ -54,13 +54,17 @@ sslThreadController function GetController(int tid)
 endfunction
 
 int function FindActorController(Actor ActorRef)
+	if !ActorRef
+		return -1
+	endIf
 	int i
 	while i < Slots.Length
-		if Slots[i].Positions.Find(ActorRef) != -1
+		if Slots[i].FindSlot(ActorRef) != -1
 			return i
 		endIf
 		i += 1
-	endWhile
+	endwhile
+
 	return -1
 endFunction
 


### PR DESCRIPTION
Check actor in current thread ActorAlias instead of Positions because some Mods check for the AnimationEnd event to start new animation with the player and in that point the thread have not ActorAlias for the actor but still have the actor in the Positions Array.