### PR TITLE
Update sslThreadController.psc

### DIFF
--- a/scripts/Source/sslThreadController.psc
+++ b/scripts/Source/sslThreadController.psc
@@ -2,7 +2,6 @@ scriptname sslThreadController extends sslThreadModel
 { Animation Thread Controller: Runs manipulation logic of thread based on information from model. Access only through functions; NEVER create a property directly to this. }
 
 ; TODO: SetFirstAnimation() - allow custom defined starter anims instead of random
-; TODO: ctrl+shift+u - 180 degree rotation
 
 import PapyrusUtil
 
@@ -175,7 +174,7 @@ state Animating
 		endIf
 		; Play SFX
 		if SoundFX && SFXTimer < RealTime[0]
-			SoundFX.Play(CenterRef)
+			SoundFX.Play(GetCenterFX())
 			SFXTimer = RealTime[0] + SFXDelay
 		endIf
 		; Loop
@@ -184,7 +183,7 @@ state Animating
 
 	function EndAction()
 		; HookStageEnd()
-		if !LeadIn && Stage > StageCount && !DisableOrgasms
+		if !LeadIn && Stage >= StageCount && !DisableOrgasms
 			SendThreadEvent("OrgasmEnd")
 		else
 			SendThreadEvent("StageEnd")
@@ -205,7 +204,11 @@ state Animating
 		if !backwards
 			GoToStage((Stage + 1))
 		elseIf backwards && Stage > 1
-			GoToStage((Stage - 1))
+			if Config.IsAdjustStagePressed()
+				GoToStage(1)
+			else
+				GoToStage((Stage - 1))
+			endIf
 		endIf
 	endFunction
 
@@ -316,7 +319,11 @@ state Animating
 
 	function RotateScene(bool backwards = false)
 		UnregisterForUpdate()
-		float Amount = SignFloat(backwards, 15.0)
+		float Amount = 15.0
+		if Config.IsAdjustStagePressed()
+			Amount = 180.0
+		endIf
+		Amount = SignFloat(backwards, Amount)
 		PlayHotkeyFX(1, !backwards)
 		CenterLocation[5] = CenterLocation[5] + Amount
 		if CenterLocation[5] >= 360.0
@@ -332,6 +339,12 @@ state Animating
 		int k = Config.RotateScene
 		while Input.IsKeyPressed(k)
 			PlayHotkeyFX(1, !backwards)
+			if Config.IsAdjustStagePressed()
+				Amount = 180.0
+			else
+				Amount = 15.0
+			endIf
+			Amount = SignFloat(backwards, Amount)
 			CenterLocation[5] = CenterLocation[5] + Amount
 			if CenterLocation[5] >= 360.0
 				CenterLocation[5] = CenterLocation[5] - 360.0
@@ -400,6 +413,9 @@ state Animating
 	function MoveScene()
 		; Stop animation loop
 		UnregisterForUpdate()
+		if UsingBed && CenterRef.IsActivationBlocked()
+			SetFurnitureIgnored(false)
+		endIf
 		; Enable Controls
 		sslActorAlias Slot = ActorAlias(PlayerRef)
 		Slot.UnlockActor()
@@ -512,8 +528,8 @@ state Animating
 
 	function TriggerOrgasm()
 		UnregisterForUpdate()
-		if SoundFX && CenterRef && CenterRef.Is3DLoaded()
-			SoundFX.Play(CenterRef)
+		if SoundFX
+			SoundFX.Play(GetCenterFX())
 		endIf
 		QuickEvent("Orgasm")
 		RegisterForSingleUpdate(0.5)
@@ -550,6 +566,11 @@ function SetAnimation(int aid = -1)
 	endIf
 	; Set active animation
 	Animation = Animations[aid]
+	; Sort actors positions if needed
+	Positions = ThreadLib.SortActorsByAnimation(Positions, Animation)
+	UpdateAdjustKey()
+	int i = ActorCount
+	
 	; Inform player of animation being played now
 	if HasPlayer
 		string msg = "Playing Animation: " + Animation.Name
@@ -586,6 +607,20 @@ function SetAnimation(int aid = -1)
 			Utility.WaitMenuMode(0.2)
 			PlayStageAnimations()
 		endIf
+	endIf
+endFunction
+
+ObjectReference function GetCenterFX()
+	if CenterRef != none && CenterRef.Is3DLoaded()
+		return CenterRef
+	else
+		int i = 0
+		while i < ActorCount
+			if Positions[i] != none && Positions[i].Is3DLoaded()
+				return Positions[i]
+			endIf
+			i += 1
+		endWhile
 	endIf
 endFunction
 
@@ -655,8 +690,12 @@ endFunction
 state Ending
 	event OnBeginState()
 		UnregisterForUpdate()
+		if UsingBed && CenterRef.IsActivationBlocked()
+			SetFurnitureIgnored(false)
+		endIf
 		; HookAnimationEnding()
 		SendThreadEvent("AnimationEnding")
+		SetObjectiveDisplayed(0, False)
 		RecordSkills()
 		DisableHotkeys()
 		Config.DisableThreadControl(self)
@@ -783,6 +822,7 @@ function Initialize()
 	SkillTime   = 0.0
 	TimedStage  = false
 	Adjusted    = false
+	Prepared    = false
 	AdjustPos   = 0
 	AdjustAlias = ActorAlias[0]
 	parent.Initialize()


### PR DESCRIPTION
Add Key combination to rotate 180 degree and return to the first stage
Temporary made beds ignored by NPC when is used for sex (need changes on sslThreadModel and sslActorAlias)
Show the scene in the map (need the CenterRef defined as objective on the thread quest)
Sort the actors based on the current animation to prevent bad gender or race position