### PR TITLE
Fix and Adjustments

### DIFF
--- a/scripts/Source/sslActorAlias.psc
+++ b/scripts/Source/sslActorAlias.psc
@@ -768,7 +768,7 @@ state Animating
 			; Lip sync and refresh expression
 			if GetState() == "Animating"
 				int Strength = CalcReaction()
-				if LoopDelay >= VoiceDelay
+				if LoopDelay >= VoiceDelay && Strength > 30
 					LoopDelay = 0.0
 					if OpenMouth && UseLipSync
 						sslBaseVoice.MoveLips(ActorRef, none, 0.5)

--- a/scripts/Source/sslBaseVoice.psc
+++ b/scripts/Source/sslBaseVoice.psc
@@ -51,8 +51,8 @@ function MoveLips(Actor ActorRef, Sound SoundRef = none, float Strength = 1.0) g
 	if ReferenceP > (1.0 - (0.2 * Strength))
 		ReferenceP = (1.0 - (0.2 * Strength))
 	endIf
-	int MinP = ((ReferenceP - (0.04 * Strength))*100) as int
-	int MaxP = ((ReferenceP + (0.16 * Strength))*100) as int
+	int MinP = ((ReferenceP - (0.1 * Strength))*100) as int
+	int MaxP = ((ReferenceP + (0.2 * Strength))*100) as int
 	if MinP < 0
 		MinP = 0
 	elseIf MinP > 98

--- a/scripts/Source/sslConfigMenu.psc
+++ b/scripts/Source/sslConfigMenu.psc
@@ -877,6 +877,8 @@ event OnSelectST()
 	elseIf Options[0] == "OpenMouthExpression"
 		if Config.GetOpenMouthExpression(Options[1] == "1") == 16
 			Config.SetOpenMouthExpression(Options[1] == "1", 15)
+		else
+			Config.SetOpenMouthExpression(Options[1] == "1", 16)
 		endIf
 		SetToggleOptionValueST(Config.GetOpenMouthExpression(Options[1] == "1") == 15)
 


### PR DESCRIPTION
Fix issue with Alternative OpenMouth don't be able of be disabled once Enabled
Increasing the MoveLips Values range
Preventing the Moaning for low enjoyment  to prevent moaning without lips movement