### PR TITLE
update gitignoire, optimize CenterOnObject() offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ SKSE/Plugins/SexLabUtil.ipdb
 SKSE/Plugins/SexLabUtil.lib
 SKSE/Plugins/SexLabUtil.pdb
 sexlab.code-workspace
+*.ppj
+.vscode

--- a/scripts/Source/sslThreadModel.psc
+++ b/scripts/Source/sslThreadModel.psc
@@ -1463,7 +1463,13 @@ function CenterOnObject(ObjectReference CenterOn, bool resync = true)
 			if Scale != 1.0
 				BedOffsets[0] = BedOffsets[0] * Scale ; (((2-Scale)*((Math.ABS(BedOffsets[0])-BedOffsets[0])/(2*Math.ABS(BedOffsets[0]))))+(Scale*((BedOffsets[0]+Math.ABS(BedOffsets[0]))/(2*BedOffsets[0]))))
 				BedOffsets[1] = BedOffsets[1] * Scale ; (((2-Scale)*((Math.ABS(BedOffsets[1])-BedOffsets[1])/(2*Math.ABS(BedOffsets[1]))))+(Scale*((BedOffsets[1]+Math.ABS(BedOffsets[1]))/(2*BedOffsets[1]))))
-				BedOffsets[2] = BedOffsets[2] * (((2-Scale)*((Math.ABS(BedOffsets[2])-BedOffsets[2])/(2*Math.ABS(BedOffsets[2]))))+(Scale*((BedOffsets[2]+Math.ABS(BedOffsets[2]))/(2*BedOffsets[2]))))
+
+				; BedOffsets[2] = BedOffsets[2] * (((2-Scale)*((Math.ABS(BedOffsets[2])-BedOffsets[2])/(2*Math.ABS(BedOffsets[2]))))+(Scale*((BedOffsets[2]+Math.ABS(BedOffsets[2]))/(2*BedOffsets[2]))))
+				If(BedOffsets[2] < 0)
+					BedOffsets[2] = BedOffsets[2] * (2 - scale) ; Assming Scale will always be in [0; 2)
+				Else
+					BedOffsets[2] = BedOffsets[2] * scale
+				EndIf
 				BedOffsets[3] = BedOffsets[3]
 				Log("Scaled Bed Offset[Forward:"+BedOffsets[0]+",Sideward:"+BedOffsets[1]+",Upward:"+BedOffsets[2]+",Rotation:"+BedOffsets[3]+"]")
 			endIf

--- a/scripts/Source/sslThreadModel.psc
+++ b/scripts/Source/sslThreadModel.psc
@@ -1470,7 +1470,7 @@ function CenterOnObject(ObjectReference CenterOn, bool resync = true)
 				Else
 					BedOffsets[2] = BedOffsets[2] * scale
 				EndIf
-				BedOffsets[3] = BedOffsets[3]
+				; BedOffsets[3] = BedOffsets[3]
 				Log("Scaled Bed Offset[Forward:"+BedOffsets[0]+",Sideward:"+BedOffsets[1]+",Upward:"+BedOffsets[2]+",Rotation:"+BedOffsets[3]+"]")
 			endIf
 			CenterLocation[0] = CenterLocation[0] + ((BedOffsets[0] * Math.sin(CenterLocation[5])) + (BedOffsets[1] * Math.cos(CenterLocation[5])))


### PR DESCRIPTION
Assuming I will be doing more of these, itd be useful if the gitignore could be updated with the files used for a vscode environment

---

The calculus for bedoffset[2] can be simplified significantly.
if you cut the function into two halves, using the "+" as delimeter
Part1 = (((2-Scale)*((Math.ABS(BedOffsets[2])-BedOffsets[2])/(2*Math.ABS(BedOffsets[2]))))
Part2 = (Scale*((BedOffsets[2]+Math.ABS(BedOffsets[2]))/(2*BedOffsets[2]))))

Then Part 1 will break down to "(2 - Scale) * (BedOffset < 0) ? 1 : 0"
And Part 2 be exactly the same but in reverse. This is due to how "Math.ABS(BedOffsets[2])-BedOffsets[2]" works. the function will either be 0 or 2 * BefOffsets[2] and diving this term by 2*BedOffsets[2] will normalize it to 1 (or 0 if the upper term is 0)

This means that either part 1 or part 2 will always be 0 depending on Z being positive or negative but both parts would always be processed 
Further, because you normalize the expression anyway, the whole line turns into nothing more than a heavily overcomplicated if-block

You can simplify the whole expression as stated in the PR, reducing the number of opcodes necessary to calculate the offset significantly