### PR TITLE
new SortActors()

### DIFF
--- a/scripts/Source/sslThreadLibrary.psc
+++ b/scripts/Source/sslThreadLibrary.psc
@@ -231,7 +231,32 @@ Actor[] function FindAnimationPartners(sslBaseAnimation Animation, ObjectReferen
 	return PapyrusUtil.RemoveActor(Positions, none)
 endFunction
 
-Actor[] function SortActors(Actor[] Positions, bool FemaleFirst = true)
+Actor[] Function SortActors(Actor[] akPositions, bool abFemaleFirst = true)
+	Log("Sort Actors | Original Array = " + akPositions)
+	int[] genders = ActorLib.GetGendersAll(akPositions)
+	int i = 0
+	While(i < akPositions.Length)
+		Actor it = akPositions[i]
+		int _it = genders[i]
+		int n = i - 1
+		While(n && !IsLesserGender(genders[n], _it))
+			akPositions[n + 1] = akPositions[n]
+			genders[n + 1] = genders[n]
+			n -= 1
+		EndWhile
+		akPositions[n + 1] = it
+		genders[n + 1] = _it
+		i += 1
+	EndWhile
+	Log("Sort Actors | Sorted Array = " + akPositions)
+	return akPositions
+EndFunction
+bool Function IsLesserGender(int i, int n)
+	; Male < Female < M.Cr < F.Cr
+	return n != i && (i == 1 || i == 3 && n == 2 || i < n)
+EndFunction
+
+Actor[] function SortActors_Legacy(Actor[] Positions, bool FemaleFirst = true)
 	int ActorCount = Positions.Length
 	int Priority   = FemaleFirst as int
 	if ActorCount < 2 || (ActorCount == 2 && ActorLib.GetGender(Positions[0]) == Priority)

--- a/scripts/Source/sslThreadLibrary.psc
+++ b/scripts/Source/sslThreadLibrary.psc
@@ -231,25 +231,25 @@ Actor[] function FindAnimationPartners(sslBaseAnimation Animation, ObjectReferen
 	return PapyrusUtil.RemoveActor(Positions, none)
 endFunction
 
-Actor[] Function SortActors(Actor[] akPositions, bool abFemaleFirst = true)
-	Log("Sort Actors | Original Array = " + akPositions)
-	int[] genders = ActorLib.GetGendersAll(akPositions)
+Actor[] Function SortActors(Actor[] Positions, bool FemaleFirst = true)
+	Log("Sort Actors | Original Array = " + Positions)
+	int[] genders = ActorLib.GetGendersAll(Positions)
 	int i = 0
-	While(i < akPositions.Length)
-		Actor it = akPositions[i]
+	While(i < Positions.Length)
+		Actor it = Positions[i]
 		int _it = genders[i]
 		int n = i - 1
 		While(n && !IsLesserGender(genders[n], _it))
-			akPositions[n + 1] = akPositions[n]
+			Positions[n + 1] = Positions[n]
 			genders[n + 1] = genders[n]
 			n -= 1
 		EndWhile
-		akPositions[n + 1] = it
+		Positions[n + 1] = it
 		genders[n + 1] = _it
 		i += 1
 	EndWhile
-	Log("Sort Actors | Sorted Array = " + akPositions)
-	return akPositions
+	Log("Sort Actors | Sorted Array = " + Positions)
+	return Positions
 EndFunction
 bool Function IsLesserGender(int i, int n)
 	; Male < Female < M.Cr < F.Cr

--- a/scripts/Source/sslThreadLibrary.psc
+++ b/scripts/Source/sslThreadLibrary.psc
@@ -234,12 +234,12 @@ endFunction
 Actor[] Function SortActors(Actor[] Positions, bool FemaleFirst = true)
 	Log("Sort Actors | Original Array = " + Positions)
 	int[] genders = ActorLib.GetGendersAll(Positions)
-	int i = 0
+	int i = 1
 	While(i < Positions.Length)
 		Actor it = Positions[i]
 		int _it = genders[i]
 		int n = i - 1
-		While(n && !IsLesserGender(genders[n], _it))
+		While(n >= 0 && !IsLesserGender(genders[n], _it))
 			Positions[n + 1] = Positions[n]
 			genders[n + 1] = genders[n]
 			n -= 1


### PR DESCRIPTION
The old common Sort() function will cycle through all actors 3 times in total and build the array step by step. The issue is that
1) the array is only sorted partially, as only those actors which are of a certain priority will actually be sorted, this means that actors [priority end + 1] will still be unsorted
2) the array is build step by step, causing a lot of reallocation and branching. The repeating calling of pushactors() is also an issue youre aware of already

This new sorting() function uses a slightly modified insertion sort, allowing for the entire array to be sorted properly. The implementation is also entirely in Papyrus (with exception of the getgender() call), meaning this function wont be slowed down by continuously calling native functions

---
For more aggressive changes here:
I do no longer recognize the FemaleFirst-argument in this function as its not used in the code anywhere
In general it would be beneficial to enforce actor positioning more, for both performance and animation quality (misalignment) Id suggest the following:
Female Victim -> Female -> Male Victim -> Male -> FCr Victim -> FCr -> MCr Victim -> MCr

This should follow general convention so majority of the existing animations shouldnt break from this 'rule enforcements' while authors and (future) animations will be able to have more control over the entire animation selection which will create a more pleasing and qualitative user experience and we can use these rules to further optimize the code :)