### PR TITLE
Fix character scaling when using non-standard race menu height

### DIFF
--- a/scripts/Source/sslActorAlias.psc
+++ b/scripts/Source/sslActorAlias.psc
@@ -189,22 +189,9 @@ bool function SetActor(Actor ProspectRef)
 	endIf
 	
 	if Config.HasNiOverride && !IsCreature
-		string[] MOD_OVERRIDE_KEY = NiOverride.GetNodeTransformKeys(ActorRef, False, isRealFemale, "NPC")
-		int idx = 0
-		While idx < MOD_OVERRIDE_KEY.Length
-			if MOD_OVERRIDE_KEY[idx] != "SexLab.esm"
-				TempScale = NiOverride.GetNodeTransformScale(ActorRef, False, isRealFemale, "NPC", MOD_OVERRIDE_KEY[idx])
-				if TempScale > 0
-					NioScale = NioScale * TempScale
-				endIf
-			else ; Remove SexLab Node if present by error
-				if NiOverride.RemoveNodeTransformScale(ActorRef, False, isRealFemale, "NPC", MOD_OVERRIDE_KEY[idx])
-					NiOverride.UpdateNodeTransform(ActorRef, False, isRealFemale, "NPC")
-				endIf
-			endIf
-			idx += 1
-		endWhile
-	;	Log(self, "NioScale("+NioScale+")")
+		if NiOverride.RemoveNodeTransformScale(ActorRef, False, isRealFemale, "NPC", "SexLab.esm")
+			NiOverride.UpdateNodeTransform(ActorRef, False, isRealFemale, "NPC")
+		endIf
 	endIf
 
 	if !Config.ScaleActors


### PR DESCRIPTION
It seems that the value returned by NetImmerse.GetNodeScale is already adjusted by NiOverride, so there is no need to also iterate the NiOverride transformation scales.

Currently the behavior is that when a character is scaled to 1.5x their size via RaceMenu then NetImmerse.GetNodeScale will return 1.5, and NiOverride.GetNodeTransformScale will also return 1.5, resulting in a NioScale of 1.5 * 1.5 = 2.25, which is then used to scale the character down by (1 / 2.25) which results in the character shrinking to 1.5 * (1 / (1.5 * 1.5)) = 0.66% their intended height.

The NiOverride is applied [here](https://github.com/expired6978/SKSE64Plugins/blob/master/skee64/NiTransformInterface.cpp#L493) which is the value returned by [NetImmerse.GetNodeScale ](https://github.com/ianpatt/skse64/blob/master/skse64/PapyrusNetImmerse.cpp#L157)